### PR TITLE
Fix: Use Wire1 if PMSA sensor is available

### DIFF
--- a/src/modules/Telemetry/AirQualityTelemetry.cpp
+++ b/src/modules/Telemetry/AirQualityTelemetry.cpp
@@ -50,7 +50,11 @@ int32_t AirQualityTelemetryModule::runOnce()
             digitalWrite(PMSA003I_ENABLE_PIN, LOW);
 #endif /* PMSA003I_ENABLE_PIN */
 
+#if defined(I2C_SDA1)
+            if (!aqi.begin_I2C(&Wire1)) {
+#else
             if (!aqi.begin_I2C()) {
+#endif
 #ifndef I2C_NO_RESCAN
                 LOG_WARN("Could not establish i2c connection to AQI sensor. Rescan");
                 // rescan for late arriving sensors. AQI Module starts about 10 seconds into the boot so this is plenty.


### PR DESCRIPTION
# CONTEXT
In the past, we needed to change to Wire1 to ensure our PMSA could connect over I2C. The code has changed since then for meshtastic so we need to change how we enable wire1 in the case we detect the pmsa is available. This is based on the original code that's described on this slide from Pete:
<img width="803" height="468" alt="image" src="https://github.com/user-attachments/assets/7f9fb198-8cce-4100-bd3d-e1a62d5b257f" />

# CHANGELOG
<!-- A brief description of the changes in this PR using the sections below -->
## ADDED
## CHANGED
- Connect to wire1 when PMSA sensor is detected
## DELETED
# ISSUE LINK 