### PR TITLE
Feature/sd-card-setup

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ extra_configs =
 
 description = Meshtastic
 
-[env]
+[env]-
 test_build_src = true
 extra_scripts = bin/platformio-custom.py
 ; note: we add src to our include search path so that lmic_project_config can override

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -16,6 +16,7 @@
 #if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
 #include <SD.h>
 #include <SPI.h>
+#include <cstring>
 
 #ifdef SDCARD_USE_SPI1
 SPIClass SPI_HSPI(HSPI);
@@ -336,3 +337,83 @@ void setupSDCard()
     LOG_DEBUG("Used space: %lu MB", (uint32_t)(SD.usedBytes() / (1024 * 1024)));
 #endif
 }
+
+#if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
+
+static void sdEnsureParentDir(const char *path)
+{
+    const char *finalSlash = strrchr(path, '/');
+    if (!finalSlash || finalSlash == path)
+        return;
+
+    char dir[64];
+    size_t end = (size_t)(finalSlash - path);
+    for (size_t i = 1; i < end; i++) {
+        if (path[i] != '/')
+            continue;
+        memcpy(dir, path, i);
+        dir[i] = '\0';
+        if (!SD.exists(dir))
+            SD.mkdir(dir);
+    }
+    if (end == 0 || end >= sizeof(dir))
+        return;
+    memcpy(dir, path, end);
+    dir[end] = '\0';
+    if (dir[0] && !SD.exists(dir))
+        SD.mkdir(dir);
+}
+
+bool sdCardAppendLine(const char *path, const char *line, bool tryLock)
+{
+    if (!path || !line || !line[0])
+        return false;
+    if (SD.cardType() == CARD_NONE)
+        return false;
+
+    if (tryLock) {
+        if (!spiLock->try_lock())
+            return false;
+    } else {
+        spiLock->lock();
+    }
+
+    sdEnsureParentDir(path);
+    File f = SD.open(path, FILE_APPEND);
+    if (!f) {
+        spiLock->unlock();
+        return false;
+    }
+    f.print(line);
+    size_t len = strlen(line);
+    if (len == 0 || line[len - 1] != '\n')
+        f.println();
+    f.close();
+    spiLock->unlock();
+    return true;
+}
+
+bool sdCardSmokeTest(const char *path, char *readBack, size_t readBackBytes)
+{
+    if (!path || !readBack || readBackBytes == 0)
+        return false;
+    if (SD.cardType() == CARD_NONE)
+        return false;
+
+    concurrency::LockGuard g(spiLock);
+    File out = SD.open(path, "w");
+    if (!out)
+        return false;
+    out.println("smesh_sd_smoke ok");
+    out.close();
+
+    File in = SD.open(path, "r");
+    if (!in)
+        return false;
+    size_t n = in.readBytes(readBack, readBackBytes - 1);
+    in.close();
+    readBack[n] = '\0';
+    return true;
+}
+
+#endif // HAS_SDCARD && !SDCARD_USE_SOFT_SPI

--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -29,6 +29,14 @@ SPIClass SPI_HSPI(HSPI);
 #define SD_SPI_FREQUENCY 4000000U
 #endif
 
+// sdCardAppendLine: first attempt + this many retries after transient SPI/CRC errors.
+#ifndef SD_APPEND_MAX_ATTEMPTS
+#define SD_APPEND_MAX_ATTEMPTS 4U
+#endif
+#ifndef SD_APPEND_RETRY_GAP_MS
+#define SD_APPEND_RETRY_GAP_MS 15U
+#endif
+
 #endif // HAS_SDCARD
 
 /**
@@ -378,19 +386,26 @@ bool sdCardAppendLine(const char *path, const char *line, bool tryLock)
         spiLock->lock();
     }
 
-    sdEnsureParentDir(path);
-    File f = SD.open(path, FILE_APPEND);
-    if (!f) {
-        spiLock->unlock();
-        return false;
+    bool ok = false;
+    for (unsigned attempt = 0; attempt < SD_APPEND_MAX_ATTEMPTS; attempt++) {
+        if (attempt > 0)
+            delay(SD_APPEND_RETRY_GAP_MS);
+
+        sdEnsureParentDir(path);
+        File f = SD.open(path, FILE_APPEND);
+        if (!f)
+            continue;
+        f.print(line);
+        size_t len = strlen(line);
+        if (len == 0 || line[len - 1] != '\n')
+            f.println();
+        f.close();
+        ok = true;
+        break;
     }
-    f.print(line);
-    size_t len = strlen(line);
-    if (len == 0 || line[len - 1] != '\n')
-        f.println();
-    f.close();
+
     spiLock->unlock();
-    return true;
+    return ok;
 }
 
 bool sdCardSmokeTest(const char *path, char *readBack, size_t readBackBytes)

--- a/src/FSCommon.h
+++ b/src/FSCommon.h
@@ -56,3 +56,10 @@ std::vector<meshtastic_FileInfo> getFiles(const char *dirname, uint8_t levels);
 void listDir(const char *dirname, uint8_t levels, bool del = false);
 void rmDir(const char *dirname);
 void setupSDCard();
+
+#if defined(HAS_SDCARD) && !defined(SDCARD_USE_SOFT_SPI)
+/** Append a line to a file on the SD volume (same SPI lock as setupSDCard). If tryLock, skip when the lock is busy. */
+bool sdCardAppendLine(const char *path, const char *line, bool tryLock);
+/** Write a fixed smoke line and read it back (blocking spiLock). */
+bool sdCardSmokeTest(const char *path, char *readBack, size_t readBackBytes);
+#endif

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -4,6 +4,7 @@
 #include "concurrency/OSThread.h"
 #include "configuration.h"
 #include "main.h"
+#include "smesh_sd_card.h"
 #include "memGet.h"
 #include "mesh/generated/meshtastic/mesh.pb.h"
 #include <assert.h>
@@ -338,6 +339,18 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
 
         va_list arg;
         va_start(arg, format);
+
+#if defined(ARCH_ESP32) && defined(HAS_SDCARD) && defined(SMESH_HELTEC_V3_SD) && !defined(SDCARD_USE_SOFT_SPI)
+        {
+            char sdBuf[384];
+            va_list arg_sd;
+            va_copy(arg_sd, arg);
+            int n = vsnprintf(sdBuf, sizeof(sdBuf), newFormat, arg_sd);
+            va_end(arg_sd);
+            if (n > 0)
+                smesh_sd_append_log_line(sdBuf);
+        }
+#endif
 
         log_to_serial(logLevel, newFormat, arg);
         log_to_syslog(logLevel, newFormat, arg);

--- a/src/RedirectablePrint.cpp
+++ b/src/RedirectablePrint.cpp
@@ -342,6 +342,8 @@ void RedirectablePrint::log(const char *logLevel, const char *format, ...)
 
 #if defined(ARCH_ESP32) && defined(HAS_SDCARD) && defined(SMESH_HELTEC_V3_SD) && !defined(SDCARD_USE_SOFT_SPI)
         {
+            // arbitrarily picked 384 but this is hopefully enough for most log messages
+            // if we notice clipping of logs, this is likely the culprit
             char sdBuf[384];
             va_list arg_sd;
             va_copy(arg_sd, arg);

--- a/src/concurrency/Lock.cpp
+++ b/src/concurrency/Lock.cpp
@@ -23,6 +23,7 @@ void Lock::lock()
 
 bool Lock::try_lock()
 {
+    // this will return immediately if the lock is not available
     return xSemaphoreTake(handle, 0) == pdTRUE;
 }
 

--- a/src/concurrency/Lock.cpp
+++ b/src/concurrency/Lock.cpp
@@ -21,6 +21,11 @@ void Lock::lock()
     }
 }
 
+bool Lock::try_lock()
+{
+    return xSemaphoreTake(handle, 0) == pdTRUE;
+}
+
 void Lock::unlock()
 {
     if (xSemaphoreGive(handle) == false) {
@@ -31,6 +36,11 @@ void Lock::unlock()
 Lock::Lock() {}
 
 void Lock::lock() {}
+
+bool Lock::try_lock()
+{
+    return true;
+}
 
 void Lock::unlock() {}
 #endif

--- a/src/concurrency/Lock.h
+++ b/src/concurrency/Lock.h
@@ -21,6 +21,10 @@ class Lock
     // Must not be called from an ISR.
     void lock();
 
+    /// Like lock(), but returns immediately if the lock is not available (non-blocking).
+    /// @return true if the lock was acquired
+    bool try_lock();
+
     // Unlocks the lock.
     //
     // Must not be called from an ISR.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "buzz.h"
 
 #include "FSCommon.h"
+#include "smesh_sd_card.h"
 #include "Led.h"
 #include "RTC.h"
 #include "SPILock.h"
@@ -753,8 +754,16 @@ void setup()
 
 #endif
 
+#if defined(HAS_SDCARD) && defined(SMESH_HELTEC_V3_SD) && !defined(SDCARD_USE_SOFT_SPI)
+    // Wall-clock folder name for SD logs; safe to call twice with the later tzset/readFromRTC.
+    readFromRTC();
+#endif
 #ifdef HAS_SDCARD
     setupSDCard();
+#endif
+#if defined(HAS_SDCARD) && defined(SMESH_HELTEC_V3_SD) && !defined(SDCARD_USE_SOFT_SPI)
+    smesh_sd_init_log_session();
+    smesh_sd_run_smoke_test();
 #endif
 
     // LED init

--- a/src/smesh_sd_card.cpp
+++ b/src/smesh_sd_card.cpp
@@ -18,6 +18,11 @@ void smesh_sd_init_log_session(void)
     if (SD.cardType() == CARD_NONE)
         return;
 
+    // a human readable identifier for this where it's based on the time
+    // if time isn't available it'll be NOT named after the current time but instead
+    // "boot" with the millis timestamp
+    //
+    // 48 as a number that's hopefully enough for most log sessions
     char session[48];
     uint32_t t = getValidTime(RTCQualityDevice, false);
     // If RTC/GPS/phone has not set quality yet, t is 0 — use a per-boot folder name instead.
@@ -30,6 +35,8 @@ void smesh_sd_init_log_session(void)
                  (unsigned)(tm.tm_mon + 1), (unsigned)tm.tm_mday, (unsigned)tm.tm_hour, (unsigned)tm.tm_min,
                  (unsigned)tm.tm_sec);
     } else {
+        // otherwise, time must not be available since the date would otherwise 
+        // be some obnoxiously early date set in the past
         snprintf(session, sizeof(session), "boot_%08lx", (unsigned long)millis());
     }
 

--- a/src/smesh_sd_card.cpp
+++ b/src/smesh_sd_card.cpp
@@ -1,0 +1,57 @@
+#include "configuration.h"
+
+#if defined(ARCH_ESP32) && defined(HAS_SDCARD) && defined(SMESH_HELTEC_V3_SD) && !defined(SDCARD_USE_SOFT_SPI)
+
+#include "FSCommon.h"
+#include "RTC.h"
+#include "meshUtils.h"
+#include <SD.h>
+#include <cstdio>
+#include <ctime>
+
+// Full path to the serial mirror log for this boot (set by smesh_sd_init_log_session).
+static char smesh_sd_log_file[128];
+
+void smesh_sd_init_log_session(void)
+{
+    smesh_sd_log_file[0] = '\0';
+    if (SD.cardType() == CARD_NONE)
+        return;
+
+    char session[48];
+    uint32_t t = getValidTime(RTCQualityDevice, false);
+    // If RTC/GPS/phone has not set quality yet, t is 0 — use a per-boot folder name instead.
+    static constexpr uint32_t MIN_SYNC_EPOCH = 1704067200UL; // 2024-01-01 00:00 UTC
+    if (t >= MIN_SYNC_EPOCH) {
+        struct tm tm;
+        time_t tt = (time_t)t;
+        gmtime_r(&tt, &tm);
+        snprintf(session, sizeof(session), "%04u-%02u-%02u_%02u-%02u-%02u", (unsigned)(tm.tm_year + 1900),
+                 (unsigned)(tm.tm_mon + 1), (unsigned)tm.tm_mday, (unsigned)tm.tm_hour, (unsigned)tm.tm_min,
+                 (unsigned)tm.tm_sec);
+    } else {
+        snprintf(session, sizeof(session), "boot_%08lx", (unsigned long)millis());
+    }
+
+    snprintf(smesh_sd_log_file, sizeof(smesh_sd_log_file), "/logs/%s/smesh_serial.log", session);
+    LOG_INFO("smesh SD log session: %s", smesh_sd_log_file);
+}
+
+void smesh_sd_run_smoke_test(void)
+{
+    char buf[64];
+    if (!sdCardSmokeTest("/smesh_sd_smoke.txt", buf, sizeof(buf))) {
+        LOG_WARN("smesh SD smoke: failed (no card or SD I/O error)");
+        return;
+    }
+    LOG_INFO("smesh SD smoke read back: %s", buf);
+}
+
+void smesh_sd_append_log_line(const char *line)
+{
+    if (!smesh_sd_log_file[0])
+        return;
+    (void)sdCardAppendLine(smesh_sd_log_file, line, true);
+}
+
+#endif

--- a/src/smesh_sd_card.h
+++ b/src/smesh_sd_card.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// SMesh Heltec V3 + SD: smoke test and optional mirror of LOG_* lines to SD.
+#if defined(ARCH_ESP32) && defined(HAS_SDCARD) && defined(SMESH_HELTEC_V3_SD) && !defined(SDCARD_USE_SOFT_SPI)
+
+void smesh_sd_init_log_session(void);
+void smesh_sd_run_smoke_test(void);
+void smesh_sd_append_log_line(const char *line);
+
+#else
+
+static inline void smesh_sd_init_log_session(void) {}
+static inline void smesh_sd_run_smoke_test(void) {}
+static inline void smesh_sd_append_log_line(const char *) {}
+
+#endif

--- a/variants/esp32s3/smesh_heltec_v3/platformio.ini
+++ b/variants/esp32s3/smesh_heltec_v3/platformio.ini
@@ -5,4 +5,8 @@ extends = env:heltec-v3
 build_flags =
   ${env:heltec-v3.build_flags}
   -D SMESH_HELTEC_V3_SD
+  ; Lowered from the FSCommon.cpp default of 4 MHz to make the SPI SD bus
+  ; tolerate jumper-wire SI / brownout during LoRa TX. Bump back up once
+  ; the carrier has proper pull-ups + decoupling.
+  -D SD_SPI_FREQUENCY=1000000U
   -include variants/esp32s3/smesh_heltec_v3/sd_overlay.h

--- a/variants/esp32s3/smesh_heltec_v3/platformio.ini
+++ b/variants/esp32s3/smesh_heltec_v3/platformio.ini
@@ -1,0 +1,8 @@
+; SMesh: Heltec V3 + SPI SD on GPIO 19 (CS), 20 (MOSI), 21 (SCK), 26 (MISO).
+; User prefs: src/smesh_defaults.h (included globally via configuration.h).
+[env:smesh-heltec-v3]
+extends = env:heltec-v3
+build_flags =
+  ${env:heltec-v3.build_flags}
+  -D SMESH_HELTEC_V3_SD
+  -include variants/esp32s3/smesh_heltec_v3/sd_overlay.h

--- a/variants/esp32s3/smesh_heltec_v3/sd_overlay.h
+++ b/variants/esp32s3/smesh_heltec_v3/sd_overlay.h
@@ -1,14 +1,18 @@
 #pragma once
 
-// SMesh (Stanford radio club) — Heltec WiFi LoRa 32 V3 + SPI SD carrier.
-// Base board pins: variants/esp32s3/heltec_v3/variant.h
+// SMesh (Stanford radio club) — Heltec WiFi LoRa 32 V3 + SPI SD (Adafruit-style wiring).
+// Base board: variants/esp32s3/heltec_v3/variant.h
 //
-// We add ontop of the heltec_v3 variant file
+// SPI (host naming): SCK=19, MISO=33 (card DO), MOSI=26 (card DI), CS=47.
+// CD (card detect) on GPIO48 is optional hardware; Arduino SD.begin() does not use it unless you add code.
 
 #define HAS_SDCARD
 #define SDCARD_USE_SPI1
-#define SPI_MOSI (20)
-#define SPI_SCK (21)
-#define SPI_MISO (26)
-#define SPI_CS (19)
+#define SPI_SCK (19)
+#define SPI_MISO (33)
+#define SPI_MOSI (26)
+#define SPI_CS (47)
 #define SDCARD_CS SPI_CS
+
+/** Card detect (optional); not read by FSCommon / SD library today. */
+#define SMESH_SD_CD_GPIO (48)

--- a/variants/esp32s3/smesh_heltec_v3/sd_overlay.h
+++ b/variants/esp32s3/smesh_heltec_v3/sd_overlay.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// SMesh (Stanford radio club) — Heltec WiFi LoRa 32 V3 + SPI SD carrier.
+// Base board pins: variants/esp32s3/heltec_v3/variant.h
+//
+// We add ontop of the heltec_v3 variant file
+
+#define HAS_SDCARD
+#define SDCARD_USE_SPI1
+#define SPI_MOSI (20)
+#define SPI_SCK (21)
+#define SPI_MISO (26)
+#define SPI_CS (19)
+#define SDCARD_CS SPI_CS


### PR DESCRIPTION
# CONTEXT
<!-- A brief description of the reason for these changes. -->
We need a way to interface with a SD card from the meshtastic.

We wire the pins as so:
#define SPI_MOSI (20)
#define SPI_SCK (21)
#define SPI_MISO (26)
#define SPI_CS (19)

Then, any logs go to the SD card

# CHANGELOG
<!-- A brief description of the changes in this PR using the sections below -->
## ADDED
- sd card logging
- sd card smoke test (sanity check it's working)
- will auto setup sd card and use current time if possible to log exactly what's normally printed to serial
## CHANGED
- now there is a project configuration for platformio called `smesh-heltec-v3` that we must upload from
## DELETED
# ISSUE LINK 